### PR TITLE
Various typos

### DIFF
--- a/Script/week_5_content.tex
+++ b/Script/week_5_content.tex
@@ -215,9 +215,9 @@ R := \frac{\log M}{n}.
 Given a code for a specific channel, we can study the probability that an error occurs while transmitting a message. For a fixed message $m$, this probability is represented by the following quantity.
 
 \begin{definition}[Probability of error]\label{def:probability-of-error}
-Given an $(M,n)$ code for a channel $(\mathcal{X},P_{Y|X},\mathcal{Y})$, the probability of error $\lambda_m$ is the probability that the decoded output is not equal to the input message $m$. More formally,
+Given an $(M,n)$ code for a channel $(\mathcal{X},P_{Y|X},\mathcal{Y})$, the probability of error $\lambda_w$ is the probability that the decoded output is not equal to the input message $w$. More formally,
 \[
-\lambda_w := P[\mathtt{dec}(Y^n) \neq m \mid X^n = \mathtt{enc}(w)].
+\lambda_w := P[\mathtt{dec}(Y^n) \neq w \mid X^n = \mathtt{enc}(w)].
 \]
 Given this quantity, the \term{maximal probability of error} is defined as 
 \[\lambda^{(n)} := \max_{w \in [M]} \lambda_w.\]
@@ -404,7 +404,7 @@ The generator matrix is used in the encoding function as follows:
 \[
 \mathtt{enc}(m) = G^T \cdot m.
 \]
-The codebook $C$ is the set $\Set{G^T \cdot m}{m \in \mathcal{X}^n}$.
+The codebook $C$ is the set $\Set{G^T \cdot m}{m \in \{0,1\}^k}$.
 \footnote{The reason for the transposition in $G^T$ is that historically, coding theorists preferred to use row vectors and matrix multiplication from the right instead of column vectors and multiplication from the left, which is more standard in other areas. Notice that for row vectors $c = m \cdot G$, we equivalently have column vectors $c^T = (m \cdot G)^T = G^T \cdot m^T$.}
 
 \begin{example}[{Generator matrix of the $[7,4]$ Hamming code}]
@@ -479,7 +479,7 @@ Notice that all columns of $H$ are different, and that there are $2^3 = 8$ possi
 \begin{example}[The 5-bit repetition code]
 The generating matrix of $R_5$, the 5-bit repetition code, is
 \[G^T = \left(\begin{array}{c}
-1\\1\\1\\1
+1\\1\\1\\1\\1
 \end{array}\right).\]
 The parity check matrix is
 \[

--- a/Script/week_5b_content.tex
+++ b/Script/week_5b_content.tex
@@ -26,7 +26,7 @@ Look again at channel (b) from Example~\ref{example:channel}, now with some spec
 \node[anchor=west] at (6,2) {1};
 \end{tikzpicture}
 \end{center}
-We can send two messages, $m_1$ and $m_2$, over the channel by defining $\enc{m_1} = a$ and $\enc{m_2} = b$. The decoding is defined as $\dec{0} = m_1$, and $\dec{1} = \dec{2} = m_2$.
+We can send two messages, $m_1$ and $m_2$, over the channel by defining $\enc{m_1} = a$ and $\enc{m_2} = b$. The decoding is defined as $\dec{1} = m_1$, and $\dec{2} = \dec{3} = m_2$.
 \end{example}
 
 
@@ -141,7 +141,7 @@ Let $(\mathcal{X},P_{Y|X},\mathcal{Y})$ be a channel. The confusability graph $G
 \[V(G) := \mathcal{X},\]
 the set of input symbols of the channel, and
 \[
-E(G) := \{\{x,x'\} \subset \mathcal{X} \mid x \neq x' \mbox{ and } \exists y \in \mathcal{Y} \mbox{ s.t. } P_{Y|X}(y|x) \cdot P_{Y_X}(y|x') > 0\}
+E(G) := \{\{x,x'\} \subset \mathcal{X} \mid x \neq x' \mbox{ and } \exists y \in \mathcal{Y} \mbox{ s.t. } P_{Y|X}(y|x) \cdot P_{Y|X}(y|x') > 0\}
 \]
 is the set of input pairs that are confusable (because they reach a shared output symbol $y \in \mathcal{Y}$).
 \end{definition}


### PR DESCRIPTION
A few typos I found with the lecture notes.

1. Def 5.2.3: I think w and m are being used interchangeably. \lambda_w was the notation used in class.
2. Def 5.2.12: In the following paragraph, m should be a vector of size k. Even though m is a binary vector, I think using \mathcal{X}^k is a confusing notation since \mathcal{X} is used to refer to the inputs set.
3. Example 5.2.17: G^T should be a 5x1 matrix
4. Example 6.0.1: The output set is {1,2,3}, but the encoding function is taking values in {0,1,2}
5. Def 6.1.3: Both should be conditional densities.
